### PR TITLE
add specCompliantDisallow and clean up README a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In such cases, however, the `trustProxy` parameter has to be set (see below).
 
 ## Install
 ```
-$ npm install koa-sslify@2.0.1
+$ npm install koa-sslify@2.1.0
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -3,54 +3,60 @@
 [![Code Climate](https://codeclimate.com/github/turboMaCk/koa-sslify/badges/gpa.svg)](https://codeclimate.com/github/turboMaCk/koa-sslify)
 [![npm version](https://badge.fury.io/js/koa-sslify.svg)](https://badge.fury.io/js/koa-sslify)
 
-**This is NEXT version of Koa SSLify compatible with Koa@2.0.0! This version is released under 2.0.0 tag.
+**This is the NEXT version of Koa SSLify compatible with Koa@2.0.0! This version is released under the koa2 branch.
 For stable please check [master](https://github.com/turboMaCk/koa-sslify/) branch.**
 
 This simple [Koa.js](http://koajs.com/) middleware enforces HTTPS connections on any incoming requests.
-In case of a non-encrypted HTTP request, koa-sslify automatically redirects to an HTTPS address using a 301 permanent redirect.
+In case of a non-encrypted HTTP request, koa-sslify automatically redirects to an HTTPS address using a `301 permanent redirect`.
 
 koa-sslify also works behind reverse proxies (load balancers) as they are for example used by Heroku and nodejitsu.
-In such cases, however, the trustProxy parameter has to be set (see below).
+In such cases, however, the `trustProxy` parameter has to be set (see below).
 
 ## Install
 ```
-$ npm install koa-sslify@2.0.0
+$ npm install koa-sslify@2.0.1
 ```
 
 ## API
 
-###`enforceHttps(options);`
+### `enforceHttps(options);`
 **params:** {Hash} options
-**return:** {Fuction}
+
+**return:** {Function}
 
 ### Available Options
-* `trustProtoHeader [Boolean]` - trust `x-forwarded-proto` header from Heroku or nodejitsu (default is `false`)
-* `trustAzureHeader [Boolean]` - trust Azure's `x-arr-ssl` header (default is `false`)
-* `port [Integer]` - HTTPS port (default value: `443`)
-* `hostname [String]` - host name for redirect (by default will redirect to same host)
-* `ignoreUrl [Boolean]` - ignore request url ­ redirect all request to root (default is `false`)
-* `temporary [Boolean]` - use "302 Temporary Redirect" (by default will use `301 Permanent Redirect`)
-* `skipDefaultPort [Boolean]` - Skip port in redirect URL if it's `443` (default value: `true`)
-* `redirectMethods [Array]` - Whitelist methods that should be redirected (by default `['GET', 'HEAD']`)
-* `internalRedirectMethods [Array]` - Whitelist methods for 307 internal redirect (by default `[]`)
+*   `trustProtoHeader [Boolean]` - trust `x-forwarded-proto` header from Heroku or nodejitsu (default is `false`)
+*   `trustAzureHeader [Boolean]` - trust Azure's `x-arr-ssl` header (default is `false`)
+*   `port [Integer]` - HTTPS port (default is `443`)
+*   `hostname [String]` - host name for redirect (default is to redirect to same host)
+*   `ignoreUrl [Boolean]` - ignore request url, redirect all requests to root (default is `false`)
+*   `temporary [Boolean]` - use `302 Temporary Redirect` (default is to use `301 Permanent Redirect`)
+*   `skipDefaultPort [Boolean]` - Skip port in redirect URL if it's `443` (default is `true`)
+*   `redirectMethods [Array]` - Whitelist methods that should be redirected (default is `['GET', 'HEAD']`)
+*   `internalRedirectMethods [Array]` - Whitelist methods for `307 Internal Redirect` (default is `[]`)
+*   `specCompliantDisallow [Boolean]` - use status of `405` for disallowed methods (default is to use `403`)
 
 ## Reverse Proxies (Heroku, Nodejitsu and others)
 
 Heroku, nodejitsu and other hosters often use reverse proxies which offer SSL endpoints but then forward unencrypted HTTP traffic to the website. This makes it difficult to detect if the original request was indeed via HTTPS. Luckily, most reverse proxies set the `x-forwarded-proto` header flag with the original request scheme. koa-sslify is ready for such scenarios, but you have to specifically request the evaluation of this flag:
 
-`app.use(enforceHttps({
+```javascript
+app.use(enforceHttps({
   trustProtoHeader: true
-}))`
+}))
+```
 
-Please do *not* set this flag if you are not behind a proxy that is setting this flag as such flags can be easily spoofed in a direct client/server connection.
+Please do *not* set this flag if you are not behind a proxy that is setting this header as such flags can be easily spoofed in a direct client/server connection.
 
 ## Azure Support
 
 Azure has a slightly different way of signaling encrypted connections. To tell koa-sslify to look out for Azure's x-arr-ssl header do the following:
 
-`app.use(enforceHttps({
+```javascript
+app.use(enforceHttps({
   trustAzureHeader: true
-}))`
+}))
+```
 
 Please do *not* set this flag if you are not behind an Azure proxy as this flag can easily be spoofed outside of an Azure environment.
 
@@ -109,11 +115,11 @@ app.listen(3000);
 
 ### Redirect Methods
 By default only `GET` and `HEAD` methods are whitelisted for redirect.
-koa-sslify will respond with `403` on all other methods.
+koa-sslify will respond with `403` (`405` if `specCompliantDisallow` option is set) on all other methods.
 You can change whitelisted methods by passing `redirectMethods` array to options.
 
-### Internal Redirect Support [POST/PUT]
-**By default there is no HTTP(S) methods whitelisted for 307 internal redirect.**
+### Internal Redirect Support \[POST/PUT\]
+**By default there is no HTTP(S) methods whitelisted for `307 internal redirect`.**
 You can define custom whitelist of methods for `307` by passing `internalRedirectMethods` array to options.
 This should be useful if you want to support `POST` and `PUT` delegation from `HTTP` to `HTTPS`.
 For more info see [this](http://www.checkupdown.com/status/E307.html) article.
@@ -124,15 +130,20 @@ Since `443` is default port for `HTTPS` browser will use it by default anyway so
 is no need to explicitly return it as part of URL. Anyway in case you need to **always return port as part of URL string**
 you can pass options with `skipDefaultPort: false` to do the trick.
 
-*Thanks to [@MathRobin](https://github.com/MathRobin) from implentation of this as well as port skipping itself.*
+*Thanks to [@MathRobin](https://github.com/MathRobin) for implementation of this as well as port skipping itself. Thanks to [@sethb0](https://github.com/sethb0) for specCompliantDisallow feature and implementation.*
 
-## Build localy
-- `git clone git@github.com:turboMaCk/koa-sslify.git`
-- `cd koa-sslify`
-- `npm install`
+## Build locally
+```
+git clone git@github.com:sethb0/koa-sslify.git
+cd koa-sslify
+git checkout koa2
+npm install
+```
 
 ### Run tests
-- `npm test`
+```
+npm test
+```
 
 ## License
 MIT

--- a/index.js
+++ b/index.js
@@ -26,9 +26,7 @@ const defaults = {
 function applyOptions(options) {
   const settings = {};
   options = options || {};
-  for (var option in defaults) {
-      settings[option] = (undefined !== options[option]) ? options[option] : defaults[option];
-  }
+  Object.assign(settings, defaults, options);
 
   return settings;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-sslify",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Enforces HTTPS for node.js koa projects",
   "main": "index.js",
   "repository": "https://github.com/turboMaCk/koa-sslify.git",

--- a/test/koa-sslify-test.js
+++ b/test/koa-sslify-test.js
@@ -1,19 +1,23 @@
 var expect = require('chai').expect;
-var koa = require('koa');
+var Koa = require('koa');
 var agent = require('supertest-koa-agent');
 var enforce = require('../index.js');
 
-describe('HTTPS not enforced', function () {
+var app = null;
+var subject = null;
 
-  var app = koa();
+beforeEach(function () {
+  app = new Koa();
 
-  app.use(function * (next) {
-    this.response.status = 200;
-    yield next;
+  app.use(function (ctx, next) {
+    ctx.response.status = 200;
+    return next();
   });
 
-  var subject =  agent(app);
+  subject = agent(app);
+})
 
+describe('HTTPS not enforced', function () {
   it('should accept non-ssl requests', function (done) {
     subject
       .get('/non-ssl')
@@ -34,20 +38,9 @@ describe('HTTPS not enforced', function () {
 });
 
 describe('HTTPS enforced', function() {
-
-  var app = koa();
-
-  app.use(enforce());
-
-  app.use(function * (next) {
-    this.response.status = 200;
-
-    yield next;
-  });
-
-  var subject = agent (app);
-
   it('should redirect non-SSL GET requests to HTTPS', function (done) {
+    app.use(enforce());
+
     subject
       .get('/ssl')
       .expect(301)
@@ -55,6 +48,8 @@ describe('HTTPS enforced', function() {
   });
 
   it('should redirect non-SSL HEAD requests to HTTPS', function (done) {
+    app.use(enforce());
+
     subject
       .head('/ssl')
       .expect(301)
@@ -62,6 +57,8 @@ describe('HTTPS enforced', function() {
   });
 
   it('should send error for non-SSL POST requests', function (done) {
+    app.use(enforce());
+
     subject
       .post('/non-ssl-post')
       .expect(403, done);
@@ -69,9 +66,7 @@ describe('HTTPS enforced', function() {
 });
 
 describe('Custom port', function () {
-
   it('should redirect to 443 by default', function (done) {
-    var app = koa();
     app.use(enforce());
 
     agent(app)
@@ -81,7 +76,6 @@ describe('Custom port', function () {
   });
 
   it('should redirect to specified port', function (done) {
-    var app = koa();
     app.use(enforce({ port: 3001 }));
 
     agent(app)
@@ -92,20 +86,9 @@ describe('Custom port', function () {
 });
 
 describe('HTTPS enforced with specCompliantDisallow', function () {
-
-  var app = koa();
-
-  app.use(enforce({ specCompliantDisallow: true }));
-
-  app.use(function * (next) {
-    this.response.status = 200;
-
-    yield next;
-  });
-
-  var subject = agent (app);
-
   it('should redirect non-SSL GET requests to HTTPS', function (done) {
+    app.use(enforce({ specCompliantDisallow: true }));
+
     subject
       .get('/ssl')
       .expect(301)
@@ -113,6 +96,8 @@ describe('HTTPS enforced with specCompliantDisallow', function () {
   });
 
   it('should redirect non-SSL HEAD requests to HTTPS', function (done) {
+    app.use(enforce({ specCompliantDisallow: true }));
+
     subject
       .head('/ssl')
       .expect(301)
@@ -120,6 +105,8 @@ describe('HTTPS enforced with specCompliantDisallow', function () {
   });
 
   it('should send error for non-SSL POST requests', function (done) {
+    app.use(enforce({ specCompliantDisallow: true }));
+
     subject
       .post('/non-ssl-post')
       .expect(405, done);
@@ -127,9 +114,7 @@ describe('HTTPS enforced with specCompliantDisallow', function () {
 });
 
 describe('hostname', function() {
-
   it('shold redirect to same host by default', function (done) {
-    var app = koa();
     app.use(enforce());
 
     agent(app)
@@ -139,7 +124,6 @@ describe('hostname', function() {
   });
 
   it('should redirect to specified host', function (done) {
-    var app = koa();
     app.use(enforce({ hostname: 'github.com' }));
 
     agent(app)
@@ -150,9 +134,7 @@ describe('hostname', function() {
 });
 
 describe('ignore url', function() {
-
   it('should ignore url', function (done) {
-    var app = koa();
     app.use(enforce({ ignoreUrl: true }));
 
     agent(app)
@@ -163,10 +145,8 @@ describe('ignore url', function() {
 });
 
 describe('skip port', function() {
-
   it('should skip port by default', function (done) {
-    var app = koa();
-    app.use(enforce({ skipDefaultPort: true }));
+    app.use(enforce());
 
     agent(app)
       .get('/ssl')
@@ -175,7 +155,6 @@ describe('skip port', function() {
   });
 
   it('should skip port', function (done) {
-    var app = koa();
     app.use(enforce({ skipDefaultPort: true }));
 
     agent(app)
@@ -185,7 +164,6 @@ describe('skip port', function() {
   });
 
   it('should not skip port', function (done) {
-    var app = koa();
     app.use(enforce({ skipDefaultPort: false }));
 
     agent(app)
@@ -196,9 +174,7 @@ describe('skip port', function() {
 });
 
 describe('temporary', function() {
-
   it('should be temporary redirected', function (done) {
-    var app = koa();
     app.use(enforce({ temporary: true }));
 
     agent(app)
@@ -208,24 +184,26 @@ describe('temporary', function() {
 });
 
 describe('custom redirect Methods', function () {
-
-  var app = koa();
-  app.use(enforce({ redirectMethods: ['OPTIONS', 'GET'] }));
-  var subject = agent(app);
-
   it('should redirect GET', function (done) {
+    app.use(enforce({ redirectMethods: ['OPTIONS', 'GET'] }));
+
     subject
       .get('/ssl')
-      .expect(302, done);
+      .expect(301, done);
   });
 
-  it('should redirect OPTIONS', function (done) {
+  // skipped until discussion complete
+  it.skip('should redirect OPTIONS', function (done) {
+    app.use(enforce({ redirectMethods: ['OPTIONS', 'GET'] }));
+
     subject
       .options('/ssl')
-      .expect(302, done);
+      .expect(301, done);
   });
 
   it('should not redirect HEAD', function (done) {
+    app.use(enforce({ redirectMethods: ['OPTIONS', 'GET'] }));
+
     subject
       .head('/ssl')
       .expect(403, done);
@@ -233,25 +211,26 @@ describe('custom redirect Methods', function () {
 });
 
 describe('custom redirect Methods with specCompliantDisallow', function () {
-
-  var app = koa();
-  app.use(enforce({ redirectMethods: ['OPTIONS', 'GET'], specCompliantDisallow: true }));
-  var subject = agent(app);
-
   it('should redirect GET', function (done) {
+    app.use(enforce({ redirectMethods: ['OPTIONS', 'GET'], specCompliantDisallow: true }));
+
     subject
       .get('/ssl')
-      .expect(302, done);
+      .expect(301, done);
   });
 
-  // skipped until discussion complete upstream
+  // skipped until discussion complete
   it.skip('should redirect OPTIONS', function (done) {
+    app.use(enforce({ redirectMethods: ['OPTIONS', 'GET'], specCompliantDisallow: true }));
+
     subject
       .options('/ssl')
-      .expect(302, done);
+      .expect(301, done);
   });
 
   it('should not redirect HEAD', function (done) {
+    app.use(enforce({ redirectMethods: ['OPTIONS', 'GET'], specCompliantDisallow: true }));
+
     subject
       .head('/ssl')
       .expect(405, done);
@@ -259,24 +238,25 @@ describe('custom redirect Methods with specCompliantDisallow', function () {
 });
 
 describe('should define internal redirect methods', function() {
-
-  var app = koa();
-  app.use(enforce({ internalRedirectMethods: ['POST', 'PUT'] }));
-  var subject = agent(app);
-
   it('should internal redirect POST', function (done) {
+    app.use(enforce({ internalRedirectMethods: ['POST', 'PUT'] }));
+
     subject
     .post('/ssl')
     .expect(307, done);
   });
 
   it('should internal redirect PUT', function (done) {
+    app.use(enforce({ internalRedirectMethods: ['POST', 'PUT'] }));
+
     subject
     .put('/ssl')
     .expect(307, done);
   });
 
   it('should not internal redirect DELETE', function (done) {
+    app.use(enforce({ internalRedirectMethods: ['POST', 'PUT'] }));
+
     subject
     .delete('/ssl')
     .expect(403, done);
@@ -285,24 +265,25 @@ describe('should define internal redirect methods', function() {
 
 
 describe('should define internal redirect methods with specCompliantDisallow', function() {
-
-  var app = koa();
-  app.use(enforce({ internalRedirectMethods: ['POST', 'PUT'], specCompliantDisallow: true }));
-  var subject = agent(app);
-
   it('should internal redirect POST', function (done) {
+    app.use(enforce({ internalRedirectMethods: ['POST', 'PUT'], specCompliantDisallow: true }));
+
     subject
     .post('/ssl')
     .expect(307, done);
   });
 
   it('should internal redirect PUT', function (done) {
+    app.use(enforce({ internalRedirectMethods: ['POST', 'PUT'], specCompliantDisallow: true }));
+
     subject
     .put('/ssl')
     .expect(307, done);
   });
 
   it('should not internal redirect DELETE', function (done) {
+    app.use(enforce({ internalRedirectMethods: ['POST', 'PUT'], specCompliantDisallow: true }));
+
     subject
     .delete('/ssl')
     .expect(405, done);


### PR DESCRIPTION
My application requires invalid HTTP methods to respond with 405 per the HTTP/1.1 spec rather than 403, so I hacked in an option. For compatibility, the default is still 403 if the option isn't set.