### PR TITLE
Added ability to set custom `proto` header

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $ npm install koa-sslify
 ### Available Options
 *   `trustProtoHeader [Boolean]` - trust `x-forwarded-proto` header from Heroku or nodejitsu (default is `false`)
 *   `trustAzureHeader [Boolean]` - trust Azure's `x-arr-ssl` header (default is `false`)
+*   `customProtoHeader [String]` - allows to provide a custom proto header name for reverse-proxies instead of the standard one: `x-forwarded-proto` (default is `undefined`)
 *   `port [Integer]` - HTTPS port (default is `443`)
 *   `hostname [String]` - host name for redirect (default is to redirect to same host)
 *   `ignoreUrl [Boolean]` - ignore request url, redirect all requests to root (default is `false`)
@@ -56,6 +57,14 @@ app.use(enforceHttps({
 ```
 
 Please do *not* set this flag if you are not behind an Azure proxy as this flag can easily be spoofed outside of an Azure environment.
+
+## Custom reverse-proxy header Support
+
+```javascript
+app.use(enforceHttps({
+  customProtoHeader: 'x-forwarded-proto-custom'
+}))
+```
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function portToUrlString(options) {
  *   @param    {Hash}       options
  *   @param    {Boolean}    options[trustProtoHeader]
  *   @param    {Boolean}    options[trustAzureHeader]
+ *   @param    {String}     options[customProtoHeader]
  *   @param    {Integer}    options[port]
  *   @param    {String}     options[hostname]
  *   @param    {Boolean}    options[ignoreUrl]
@@ -79,6 +80,12 @@ module.exports = function enforceHTTPS(options) {
     // indicating a SSL connection
     if (!secure && options.trustAzureHeader && ctx.request.header["x-arr-ssl"]) {
       secure = true;
+    }
+
+    // Forth, if a custom request headers can be trusted (e.g. because they are send
+    // by a proxy), check if sp,e custom header (instead of x-forwarded-proto) is set to https
+    if (!secure && options.customProtoHeader) {
+      secure = ctx.request.header[options.customProtoHeader] === 'https';
     }
 
     if (secure) {

--- a/test/koa-sslify-custom-proto-test.js
+++ b/test/koa-sslify-custom-proto-test.js
@@ -1,0 +1,63 @@
+var Koa = require('koa');
+var agent = require('supertest-koa-agent');
+var enforce = require('../index.js');
+
+var customProtoHeader = 'x-forwarded-proto-custom';
+
+describe('Custom proxy SSL flag', () => {
+
+  describe('Flag is not set', () => {
+    var app = new Koa();
+
+    app.use(enforce());
+
+    app.use((ctx) => {
+      ctx.response.status = 200;
+    });
+
+    var subject = agent(app);
+
+    it(`should ignore ${customProtoHeader} if not activated`, done => {
+      subject
+        .get('/ssl')
+        .set(customProtoHeader, 'https')
+        .expect(301)
+        .expect('location', new RegExp('^https://[\\S]*/ssl$'), done);
+    });
+
+  });
+
+  describe('Flag is set', () => {
+    var app = new Koa();
+
+    app.use(enforce({ customProtoHeader }));
+
+    app.use((ctx) => {
+      ctx.response.status = 200;
+    });
+
+    var subject = agent(app);
+
+    it('should accept request if flag set and activated', done => {
+      subject
+        .get('/ssl')
+        .set(customProtoHeader, 'https')
+        .expect(200, 'OK', done);
+    });
+
+    it('should redirect if activated but flag not set', done => {
+      subject
+        .get('/ssl')
+        .expect(301)
+        .expect('location', new RegExp('^https://[\\S]*/ssl$'), done);
+    });
+
+    it('should redirect if activated but wrong flag set', done => {
+      subject
+        .get('/ssl')
+        .set(`${customProtoHeader}s`, 'https')
+        .expect(301)
+        .expect('location', new RegExp('^https://[\\S]*/ssl$'), done);
+    });
+  });
+});


### PR DESCRIPTION
I need this ability (and I assume more ppl as well) since our reverse-proxy (Kong) doesn't use the default `x-forwarded-proto` but has a custom one, so if I'll have the ability to define it - it'll be great.