### PR TITLE
return the next koa middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function factory(options) {
 
     // Next if secure
     if (options.resolver(ctx)) {
-      next();
+      return next();
     }
     // Redirect to HTTPS
     else {


### PR DESCRIPTION
Koa requires the next() function to either be awaited or returned.